### PR TITLE
Comply with PEP440 version identification (warning during install)

### DIFF
--- a/pyhrf_viewer/__init__.py
+++ b/pyhrf_viewer/__init__.py
@@ -6,4 +6,4 @@
 This is design to work with the PyHRF package but it should work with any Nifti
 files."""
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"


### PR DESCRIPTION
minimum version is 0.1
0.0.1 is understood as 0.0.0 (and even 0.0.0>0.0.1)
